### PR TITLE
Update naturalsort_defaultcollator.php. Fixes #13982

### DIFF
--- a/lib/private/naturalsort_defaultcollator.php
+++ b/lib/private/naturalsort_defaultcollator.php
@@ -11,9 +11,9 @@ namespace OC;
 
 class NaturalSort_DefaultCollator {
 	public function compare($a, $b) {
-		if ($a === $b) {
+		if (strnatcasecmp($a, $b) == 0) {
 			return 0;
 		}
-		return ($a < $b) ? -1 : 1;
+		return (strnatcasecmp($a, $b) < 0) ? -1 : 1;
 	}
 }


### PR DESCRIPTION
This fixes file sorting in environments that can not make use of the php5-intl extension (like some shared hosting). NaturalSort_DefaultCollator now uses `strnatcasecmp()`. See #13982 for details.